### PR TITLE
Fix missing explicit function namespace

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ License: CC0
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.3.3
 Imports: 
     sf (>= 0.9),
     dplyr (>= 1.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pathroutr
 Title: An R Package for (Re-)Routing Paths Around Barriers
-Version: 0.2.1
+Version: 0.2.2
 Authors@R: 
     person(given = "Josh",
            family = "London",

--- a/R/get_barrier_segments.R
+++ b/R/get_barrier_segments.R
@@ -19,15 +19,15 @@
 
 get_barrier_segments = function(trkpts, barrier) {
   stopifnot("barrier must be a simple feature collection with geometry type 'POLYGON' or 'MULTIPOLYGON" =
-              inherits(barrier %>% st_geometry(), 'sfc_POLYGON') |
-              inherits(barrier %>% st_geometry(), 'sfc_MULTIPOLYGON')
+              inherits(barrier %>% sf::st_geometry(), 'sfc_POLYGON') |
+              inherits(barrier %>% sf::st_geometry(), 'sfc_MULTIPOLYGON')
   )
   stopifnot("trkpts must be a simple feature collection with geometry type 'POINT' or 'MULTIPOINT" =
-              inherits(trkpts %>% st_geometry(), 'sfc_POINT') |
-              inherits(trkpts %>% st_geometry(), 'sfc_MULTIPOINT')
+              inherits(trkpts %>% sf::st_geometry(), 'sfc_POINT') |
+              inherits(trkpts %>% sf::st_geometry(), 'sfc_MULTIPOINT')
   )
 
-  trkpts <- sf::st_cast(trkpts, 'POINT') %>% st_geometry()
+  trkpts <- sf::st_cast(trkpts, 'POINT') %>% sf::st_geometry()
 
   barrier_intersect <- sf::st_intersects(trkpts, barrier) %>%
     purrr::map_lgl(~ length(.x) > 0)

--- a/R/prt_extend_path.R
+++ b/R/prt_extend_path.R
@@ -15,11 +15,11 @@
 prt_extend_path<- function(l_geom, start_pt, end_pt) {
 
   if(nrow(l_geom) == 0) {
-    l <- c(start_pt,end_pt) %>% st_combine() %>% st_cast('LINESTRING')
+    l <- c(start_pt,end_pt) %>% sf::st_combine() %>% sf::st_cast('LINESTRING')
     return(l)
   }
-  l <- st_sf(l_geom) %>% summarise(do_union=FALSE) %>%
-    st_line_merge() %>% st_geometry()
+  l <- sf::st_sf(l_geom) %>% dplyr::summarise(do_union=FALSE) %>%
+    sf::st_line_merge() %>% sf::st_geometry()
   l_start <- lwgeom::st_startpoint(l)
   l_end <- lwgeom::st_endpoint(l)
 
@@ -33,10 +33,10 @@ prt_extend_path<- function(l_geom, start_pt, end_pt) {
     l_end <- lwgeom::st_endpoint(l)
   }
 
-  l1 <- c(start_pt,l_start) %>% st_combine() %>% st_cast('LINESTRING')
-  l2 <- c(end_pt, l_end) %>% st_combine() %>% st_cast('LINESTRING')
+  l1 <- c(start_pt,l_start) %>% sf::st_combine() %>% sf::st_cast('LINESTRING')
+  l2 <- c(end_pt, l_end) %>% sf::st_combine() %>% sf::st_cast('LINESTRING')
 
-  l <- c(l1,l,l2) %>% st_combine() %>% st_line_merge()
+  l <- c(l1,l,l2) %>% sf::st_combine() %>% sf::st_line_merge()
 
   return(l)
 }

--- a/R/prt_nearestnode.R
+++ b/R/prt_nearestnode.R
@@ -8,7 +8,7 @@
 #' @export
 
 prt_nearestnode <- function(segs_tbl, vis_graph) {
-  segs_tbl <- segs_tbl %>% ungroup() %>%
+  segs_tbl <- segs_tbl %>% dplyr::ungroup() %>%
     dplyr::mutate(
       start_node = nabor::knn(sf::st_coordinates(sfnetworks::activate(vis_graph,"nodes")),
                               sf::st_coordinates(.$start_pt),

--- a/R/prt_reroute.R
+++ b/R/prt_reroute.R
@@ -33,13 +33,13 @@
 prt_reroute <- function(trkpts, barrier, vis_graph, blend=TRUE) {
   stopifnot(
     "barrier must be a simple feature collection with geometry type 'POLYGON' or 'MULTIPOLYGON" =
-      inherits(barrier %>% st_geometry(), 'sfc_POLYGON') |
-      inherits(barrier %>% st_geometry(), 'sfc_MULTIPOLYGON')
+      inherits(barrier %>% sf::st_geometry(), 'sfc_POLYGON') |
+      inherits(barrier %>% sf::st_geometry(), 'sfc_MULTIPOLYGON')
   )
   stopifnot(
     "trkpts must be a simple feature collection with geometry type 'POINT' or 'MULTIPOINT" =
-      inherits(trkpts %>% st_geometry(), 'sfc_POINT') |
-      inherits(trkpts %>% st_geometry(), 'sfc_MULTIPOINT')
+      inherits(trkpts %>% sf::st_geometry(), 'sfc_POINT') |
+      inherits(trkpts %>% sf::st_geometry(), 'sfc_MULTIPOINT')
   )
   stopifnot(
     "trkpts and barrier must have the same CRS" =

--- a/R/prt_shortpath.R
+++ b/R/prt_shortpath.R
@@ -46,7 +46,7 @@ prt_shortpath <- function(segs_tbl, vis_graph, blend = TRUE) {
   })
 
   edge_geom <- lapply(route_edges, function(e) {
-    g <- vis_graph %>% as_tibble(spatial = FALSE)
+    g <- vis_graph %>% tibble::as_tibble(spatial = FALSE)
     g[e,"geometry"]
   })
 
@@ -54,7 +54,7 @@ prt_shortpath <- function(segs_tbl, vis_graph, blend = TRUE) {
     prt_extend_path(edge_geom[[i]], segs_tbl$start_pt[i], segs_tbl$end_pt[i])
   })
   segs_tbl <- segs_tbl %>%
-    mutate(geometry = st_sfc(path_geom, crs = sf::st_crs(vis_graph)))
+    dplyr::mutate(geometry = sf::st_sfc(path_geom, crs = sf::st_crs(vis_graph)))
 
   return(segs_tbl)
 

--- a/R/prt_trim.R
+++ b/R/prt_trim.R
@@ -7,13 +7,12 @@
 #' representing the barrier feature. Should be the same barrier as supplied to the
 #' `prt_visgraph()` function.
 #'
-#' @return
 #' @export
 #'
 prt_trim <- function(trkpts, barrier) {
   stopifnot("trkpts must be a simple feature collection with geometry type 'POINT' or 'MULTIPOINT" =
-              inherits(trkpts %>% st_geometry(), 'sfc_POINT') |
-              inherits(trkpts %>% st_geometry(), 'sfc_MULTIPOINT')
+              inherits(trkpts %>% sf::st_geometry(), 'sfc_POINT') |
+              inherits(trkpts %>% sf::st_geometry(), 'sfc_MULTIPOINT')
   )
   trkpts <- sf::st_cast(trkpts, 'POINT')
   barrier_intersect <- sf::st_intersects(trkpts, barrier) %>%

--- a/R/prt_visgraph.R
+++ b/R/prt_visgraph.R
@@ -16,8 +16,8 @@ prt_visgraph <- function(barrier,
                          aug_points = NULL) {
   # check barrier is of the proper geometry type
   stopifnot("barrier must be a simple feature collection with geometry type 'POLYGON' or 'MULTIPOLYGON" =
-              inherits(barrier %>% st_geometry(), 'sfc_POLYGON') |
-              inherits(barrier %>% st_geometry(), 'sfc_MULTIPOLYGON')
+              inherits(barrier %>% sf::st_geometry(), 'sfc_POLYGON') |
+              inherits(barrier %>% sf::st_geometry(), 'sfc_MULTIPOLYGON')
             )
 
   # cast barrier into polygons and union into a single MULTIPOLYGON feature
@@ -33,11 +33,11 @@ prt_visgraph <- function(barrier,
 
   if (!is.null(aug_points)) {
     stopifnot("aug_points must be a simple feature collection with geometry type 'POINT'" =
-                inherits(aug_points %>% st_geometry(), 'sfc_POINT')
+                inherits(aug_points %>% sf::st_geometry(), 'sfc_POINT')
     )
     augment <- TRUE
     aug_pts <- aug_points %>%
-      st_geometry()
+      sf::st_geometry()
 
   } else {
     augment <- FALSE
@@ -65,7 +65,7 @@ prt_visgraph <- function(barrier,
       sf::st_triangulate(bOnlyEdges = TRUE) %>%
       sf::st_cast('LINESTRING') %>%
       sf::st_sf()
-    crosses <- do.call(c, st_intersects(st_buffer(barrier,-1), edges))
+    crosses <- do.call(c, sf::st_intersects(sf::st_buffer(barrier,-1), edges))
 
     edges <- edges[-crosses,]
   }
@@ -92,7 +92,7 @@ prt_visgraph <- function(barrier,
       sf::st_triangulate(bOnlyEdges = TRUE) %>%
       sf::st_cast('LINESTRING') %>%
       sf::st_sf()
-    crosses <- do.call(c, st_intersects(st_buffer(barrier,-1), edges))
+    crosses <- do.call(c, sf::st_intersects(sf::st_buffer(barrier,-1), edges))
 
     edges <- edges[-crosses,]
   }
@@ -114,7 +114,7 @@ prt_visgraph <- function(barrier,
       sf::st_triangulate(bOnlyEdges = TRUE) %>%
       sf::st_cast('LINESTRING') %>%
       sf::st_sf()
-    crosses <- do.call(c, st_intersects(st_buffer(barrier,-1), edges))
+    crosses <- do.call(c, sf::st_intersects(sf::st_buffer(barrier,-1), edges))
 
     edges <- edges[-crosses,]
   }
@@ -127,7 +127,7 @@ prt_visgraph <- function(barrier,
       sf::st_cast('LINESTRING') %>%
       sf::st_sf()
 
-    crosses <- do.call(c, st_intersects(st_buffer(barrier,-1), edges))
+    crosses <- do.call(c, sf::st_intersects(sf::st_buffer(barrier,-1), edges))
 
     edges <- edges[-crosses,]
   }

--- a/man/get_barrier_segments.Rd
+++ b/man/get_barrier_segments.Rd
@@ -16,14 +16,13 @@ representing the barrier feature. Should be the same barrier as supplied to the
 \code{prt_visgraph()} function.}
 }
 \value{
-data.frame representing segments of consecutive points that intersect with
-barrier feature. the \emph{start_pt} and \emph{end_pt} geometry columns represent the bookend
+tibble representing segments of consecutive points that intersect with
+the barrier feature. the \emph{start_pt} and \emph{end_pt} geometry columns represent the bookend
 points for each segment that do not intersect with the barrier feature. The \emph{n_pts}
 column is the number of points to be re-routed.
 }
 \description{
 This function identifies the segments of consecutive points that intersect with the
-barrier polygon feature. The result is a data frame of segment records that identify
-portions of the track that will need to be re-routed. The result from this function
-can be directly passed into the \code{prt_nearestnode()}.
+barrier polygon feature. The result is a tibble of segment records that identify
+portions of the track that will need to be re-routed.
 }

--- a/man/prt_extend_path.Rd
+++ b/man/prt_extend_path.Rd
@@ -17,5 +17,8 @@ prt_extend_path(l_geom, start_pt, end_pt)
 linestring
 }
 \description{
-Extend a path to include given start and end points
+This function extends the calculated shortest path to start and end with
+the provided \emph{start_pt} and \emph{end_pt} geometries. This ensures that the
+final sample of new points along the re-routed path include the portion
+of the line from the \emph{start_pt}/\emph{end_pt} to the nearest network node.
 }

--- a/man/prt_nearestnode.Rd
+++ b/man/prt_nearestnode.Rd
@@ -12,7 +12,7 @@ prt_nearestnode(segs_tbl, vis_graph)
 \item{vis_graph}{sfnetwork output from \code{prt_visgraph()}}
 }
 \value{
-data frame with updated columns for nearest start and end nodes
+segs_tbl tibble with updated columns for nearest start and end nodes
 }
 \description{
 Find the nearest node for start and end points in segs_tbl

--- a/man/prt_reroute.Rd
+++ b/man/prt_reroute.Rd
@@ -31,3 +31,14 @@ the \code{prt_visgraph()} function. The output can be used as a starting point f
 process to replace the original geometry. Or, provide the output tibble directly to
 \code{prt_update_points()} along with \emph{trkpts} for simply updating in place.
 }
+\details{
+The \code{blend = TRUE} argument will blend all of the \emph{start_pt} / \emph{end_pt}
+geometries in \emph{segs_tbl} into the \emph{vis_graph} network via the
+\code{sfnetworks::st_network_blend()} function. This process creates new nodes
+within \emph{vis_graph} that are positioned at the perpendicular intersection
+between each point and the nearest edge. With \code{blend = FALSE} the nearest
+existing node is used. In highly complex coastlines, the use of \code{blend = FALSE}
+could result in re-routed paths that still intersect land or do not
+accurately represent the intended result. For less complex situations and
+when computational speed is important, \code{blend = FALSE} may be appropriate.
+}

--- a/man/prt_shortpath.Rd
+++ b/man/prt_shortpath.Rd
@@ -7,7 +7,7 @@
 prt_shortpath(segs_tbl, vis_graph, blend = TRUE)
 }
 \arguments{
-\item{segs_tbl}{tbl from \code{get_barrier_segments()}}
+\item{segs_tbl}{tibble from \code{get_barrier_segments()}}
 
 \item{vis_graph}{sfnetwork from prt_visgraph()}
 
@@ -18,5 +18,22 @@ segs_tbl data frame with added geometry column for shortest path LINESTRING that
 connects the \emph{start_pt} and \emph{end_pt} coordinates
 }
 \description{
-Calculate the shortest path through a visibility network between two points
+Given a \emph{segs_tbl} tibble created by \code{get_barrier_segments()} and a
+\emph{vis_graph} created by \code{prt_visgraph()}, this function adds a geometry
+column to \emph{segs_tbl} that is the shortest path from the POINT geometries
+provided in the \emph{start_pt} / \emph{end_pt} columns of \emph{segs_tbl}.
+}
+\details{
+The \code{blend = TRUE} argument will blend all of the \emph{start_pt} / \emph{end_pt}
+geometries in \emph{segs_tbl} into the \emph{vis_graph} network via the
+\code{sfnetworks::st_network_blend()} function. This process creates new nodes
+within \emph{vis_graph} that are positioned at the perpendicular intersection
+between each point and the nearest edge. With \code{blend = FALSE} the nearest
+existing node is used. In highly complex coastlines, the use of \code{blend = FALSE}
+could result in re-routed paths that still intersect land or do not
+accurately represent the intended result. For less complex situations and
+when computational speed is important, \code{blend = FALSE} may be appropriate.
+
+This function is typically called directly by \code{prt_reroute} and users are
+discouraged from using this function directly.
 }

--- a/man/prt_trim.Rd
+++ b/man/prt_trim.Rd
@@ -15,9 +15,6 @@ the bounding box of the barrier polygon.}
 representing the barrier feature. Should be the same barrier as supplied to the
 \code{prt_visgraph()} function.}
 }
-\value{
-
-}
 \description{
 Trim tracks to start and end outside barrier
 }

--- a/man/prt_visgraph.Rd
+++ b/man/prt_visgraph.Rd
@@ -24,7 +24,7 @@ prt_visgraph(
 \item{aug_points}{simple feature 'POINT' or 'MULTIPOINT' as additional nodes}
 }
 \value{
-SpatialLinesNetwork
+sfnetwork
 }
 \description{
 Create a visibility graph


### PR DESCRIPTION
Addresses #29

Adds explicit namespace for a few `sf`, `dplyr`, and `tibble` functions and updates documentation accordingly.